### PR TITLE
feat: 识别 JingMatrix Vector 为受支持的 libxposed 运行时

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/util/ModuleStatus.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/ModuleStatus.kt
@@ -27,11 +27,21 @@ object ModuleStatus {
     }
 
     fun classifyFrameworkName(frameworkName: String?): FrameworkCategory {
-        return if (frameworkName?.trim() == "LSPosed") {
-            FrameworkCategory.LSPOSED
-        } else {
-            FrameworkCategory.UNSUPPORTED
-        }
+        val name = frameworkName?.trim().orEmpty()
+        if (name.isEmpty()) return FrameworkCategory.UNSUPPORTED
+
+        val lower = name.lowercase()
+        // LSPatch / NPatch remain out of scope: they are in-APK patch loaders, not a system framework.
+        if ("lspatch" in lower || "npatch" in lower) return FrameworkCategory.UNSUPPORTED
+
+        // Official LSPosed name, plus JingMatrix Vector (the LSPosed repo rename / successor).
+        // Vector 2.x may report "Vector", "JingMatrix-Vector", or "<id>-JingMatrix-Vector".
+        if (name == "LSPosed") return FrameworkCategory.LSPOSED
+        if (name.equals("Vector", ignoreCase = true)) return FrameworkCategory.LSPOSED
+        if (name.contains("JingMatrix-Vector", ignoreCase = true)) return FrameworkCategory.LSPOSED
+        if (lower.endsWith("-vector") || lower.endsWith(" vector")) return FrameworkCategory.LSPOSED
+
+        return FrameworkCategory.UNSUPPORTED
     }
 
     fun isSupportedLsposedFramework(frameworkName: String?, apiVersion: Int): Boolean {


### PR DESCRIPTION
## 背景

JingMatrix 已将 [LSPosed](https://github.com/JingMatrix/LSPosed) 仓库改名为 [Vector](https://github.com/JingMatrix/Vector)。GitHub 旧地址会跳转到新仓库，二者是同一条维护线。

当前 `ModuleStatus.classifyFrameworkName()` 要求 `frameworkName` **正好等于** `"LSPosed"`。Vector 2.x 通过 libxposed 上报的官方名是 `Vector` / `JingMatrix-Vector`（例如 `38d3f136-JingMatrix-Vector`），API 已经是 102，但仍会被判定为 `UNSUPPORTED`，随后 `LibXposedRuntime` 执行 `module.detach()`，停止安装 Hook。

这不是补丁式分发，也不是 LSPatch / NPatch。

## 改动

只改 `ModuleStatus.kt` 的框架名识别：

- 继续接受精确匹配的 `LSPosed`
- 额外接受 `Vector`、`JingMatrix-Vector`、以及 `<id>-JingMatrix-Vector` 这类官方名
- **仍然拒绝** LSPatch / NPatch（内置打包 / 补丁式加载器）
- `libxposed API 102+` 门槛不变

未改包名、签名校验、`RuntimeIdentityGuard`、目标应用版本或其他运行边界。

## 验证

- 设备：JingMatrix Vector 2.2 (canary 3098)，libxposed API 102
- 官方包在该环境下会显示「当前框架不在支持范围内」并停止 Hook
- 本改动后，同一套检测会把 Vector 归为受支持运行时（API 仍须 ≥ 102）

## 说明

README / CONTRIBUTING 里的「支持维护范围」目前仍写 LSPosed。本 PR 只把运行时白名单对齐到 JingMatrix 的改名，不扩大到 LSPatch 或其他框架。若维护者希望文档也写上 Vector，可以在本 PR 后续补一行。